### PR TITLE
Compatibility with hnc 0.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT = mysql_hnc
 PROJECT_DESCRIPTION = MySQL/OTP + hnc
-PROJECT_VERSION = 0.1.0
+PROJECT_VERSION = 0.2.0
 DEPS = mysql hnc
 dep_mysql = git https://github.com/mysql-otp/mysql-otp.git master
-dep_hnc = git https://github.com/juhlig/hnc.git 0.1.0
+dep_hnc = git https://github.com/juhlig/hnc.git 0.2.0
 include erlang.mk

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ first parameter.
 
 Sometimes you need to checkout a connection to execute multiple queries on it,
 without wrapping it in an SQL transaction. For this purpose you can use either
-a pair of calls to `checkout/1` and `checkin/2` or a call to `with/2` with a
+a pair of calls to `checkout/1` and `checkin/1` or a call to `with/2` with a
 fun as in this example:
 
 ```Erlang
@@ -99,6 +99,16 @@ fun as in this example:
 ok
 ```
 
+Using `checkout/1` and `checkin/1`
+----------------------------------
+
+The function `checkout/1` does not return a MySQL connection directly but a
+connection _identifier_ (actually, a `hnc` worker identifier). You have to
+unpack the real connection with a call to `get_connection/1` first.
+
+Accordingly, the function `checkin/1` does not expect a MySQL connection but
+the connection _identifier_ from which it was unpacked.
+
 Use this as a dependency
 ------------------------
 
@@ -106,7 +116,7 @@ Using *erlang.mk*, put this in your `Makefile`:
 
 ```Erlang
 DEPS = mysql_hnc
-dep_mysql_hnc = git https://github.com/mysql-otp/mysql-otp-hnc 0.1.0
+dep_mysql_hnc = git https://github.com/mysql-otp/mysql-otp-hnc 0.2.0
 ```
 
 Using *rebar*, put this in your `rebar.config`:
@@ -114,7 +124,7 @@ Using *rebar*, put this in your `rebar.config`:
 ```Erlang
 {deps, [
     {mysql_hnc, ".*", {git, "https://github.com/mysql-otp/mysql-otp-hnc",
-                           {tag, "0.1.0"}}}
+                           {tag, "0.2.0"}}}
 ]}.
 ```
 

--- a/ebin/mysql_hnc.app
+++ b/ebin/mysql_hnc.app
@@ -17,7 +17,7 @@
 %% along with this program. If not, see <https://www.gnu.org/licenses/>.
 {application, mysql_hnc, [
     {description, "MySQL/OTP + hnc"},
-    {vsn, "0.1.0"},
+    {vsn, "0.2.0"},
     {modules, ['mysql_hnc','mysql_hnc_app','mysql_hnc_sup']},
     {mod, {mysql_hnc_app, []}},
     {applications, [kernel, stdlib, mysql, hnc]}


### PR DESCRIPTION
The API of hnc changed with version 0.2.0, using worker _identifiers_ instead of workers directly.